### PR TITLE
FE overhaul to reduce to only working metrics and clean up Cluster UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ import Props from './types/types';
 import '@fontsource-variable/montserrat';
 
 export default function App(props: Props) {
-  const drawerWidth = 200;
+  const drawerWidth = 220;
 
   const openedMixin = (theme: Theme): CSSObject => ({
     backgroundColor: '#0d090a',
@@ -78,15 +78,12 @@ export default function App(props: Props) {
   }));
 
   const {
-    // login,
-    // signup,
-    // connect,
+    connect,
     brokerStats,
-    brokerUtil,
-    brokerIO,
-    topicIO,
-    networkEff,
+    // brokerIO,
     partitionStats,
+    networkEff,
+    resourceUtil,
   } = props;
 
   const [open, setOpen] = React.useState(true); // switch to false to change drawer to be closed on App load
@@ -143,75 +140,74 @@ export default function App(props: Props) {
         </Toolbar>
         <Divider color="#f8fbfd" />
         <List>
-          {['Cluster', 'Broker', 'Consumer'].map((text, index) => (
-            <ListItem
-              key={text}
-              disablePadding
-              onClick={
-                index === 0
-                  ? () => {
-                      navigate('/cluster');
-                    }
-                  : index === 1
-                  ? () => {
-                      navigate('/broker');
-                    }
-                  : () => {
-                      navigate('/consumer');
-                    }
-              }
-              sx={{
-                display: 'block',
-              }}
-            >
-              <ListItemButton
+          {['Saved Connections', 'New Connection', 'Cluster Metrics'].map(
+            (text, index) => (
+              <ListItem
+                key={text}
+                disablePadding
+                onClick={
+                  index === 0
+                    ? () => {
+                        navigate('/saved');
+                      }
+                    : index === 1
+                    ? () => {
+                        navigate('/connect');
+                      }
+                    : () => {
+                        navigate('/cluster');
+                      }
+                }
                 sx={{
-                  minHeight: 48,
-                  justifyContent: open ? 'initial' : 'center',
-                  px: 2.5,
+                  display: 'block',
                 }}
               >
-                <ListItemIcon
+                <ListItemButton
                   sx={{
-                    minWidth: 0,
-                    mr: open ? 3 : 'auto',
-                    justifyContent: 'center',
-                    color: '#f8fbfd',
+                    minHeight: 48,
+                    justifyContent: open ? 'initial' : 'center',
+                    px: 2.5,
                   }}
                 >
-                  {index === 0 ? (
-                    <HubIcon />
-                  ) : index === 1 ? (
-                    <DeviceHubIcon />
-                  ) : (
-                    <PolylineIcon />
-                  )}
-                </ListItemIcon>
-                <ListItemText
-                  primary={
-                    <Typography variant="inherit" fontFamily="inherit">
-                      {text}
-                    </Typography>
-                  }
-                  sx={{
-                    opacity: open ? 1 : 0,
-                  }}
-                />
-              </ListItemButton>
-            </ListItem>
-          ))}
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 0,
+                      mr: open ? 3 : 'auto',
+                      justifyContent: 'center',
+                      color: '#f8fbfd',
+                    }}
+                  >
+                    {index === 0 ? (
+                      <HubIcon />
+                    ) : index === 1 ? (
+                      <DeviceHubIcon />
+                    ) : (
+                      <PolylineIcon />
+                    )}
+                  </ListItemIcon>
+                  <ListItemText
+                    primary={
+                      <Typography variant="inherit" fontFamily="inherit">
+                        {text}
+                      </Typography>
+                    }
+                    sx={{
+                      opacity: open ? 1 : 0,
+                    }}
+                  />
+                </ListItemButton>
+              </ListItem>
+            )
+          )}
         </List>
       </Drawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
-        {/* {login}
-        {signup}
-        {connect} */}
+        {connect}
         {brokerStats}
-        {brokerUtil}
-        {brokerIO}
-        {topicIO}
-        {networkEff}
+        {/* {brokerIO} */}
         {partitionStats}
+        {networkEff}
+        {resourceUtil}
       </Box>
     </Box>
   );

--- a/src/components/BrokerIO.tsx
+++ b/src/components/BrokerIO.tsx
@@ -8,6 +8,8 @@ export default function BrokerIO() {
       <Typography variant="subtitle2" fontFamily="inherit" align="center">
         Broker I/O
       </Typography>
+
+      {/* Following were metrics that were used in BrokerStats directly */}
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
           <Grid item xs sm md>

--- a/src/components/BrokerStats.tsx
+++ b/src/components/BrokerStats.tsx
@@ -1,8 +1,9 @@
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import Skeleton from '@mui/material/Skeleton';
+// import Skeleton from '@mui/material/Skeleton';
 import './../App.css';
+
 // Referenced:
 // https://mui.com/material-ui/react-grid/#auto-layout
 // https://mui.com/material-ui/react-grid/#responsive-values
@@ -15,15 +16,11 @@ export default function BrokerStats() {
       </Typography>
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
-          <Grid item xs sm md>
+          <Grid item xs={2} sm={2} md={2}>
             {/* Online brokers (stat) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=44"></iframe>
           </Grid>
           <Grid item xs sm md>
-            {/* Offline brokers (stat) - cannot find on Grafana Dashboards, will need to custom query */}
-            <Skeleton animation={false} variant="rectangular" height={160} />
-          </Grid>
-          <Grid item xs={2.4} sm={2.4} md={2.4}>
             {/* Active controllers (stat) (EITHER count OR count and broker ID?) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=31"></iframe>
           </Grid>
@@ -32,11 +29,33 @@ export default function BrokerStats() {
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=9"></iframe>
           </Grid>
           <Grid item xs sm md>
-            {/* Avg RF (stat) */}
-            <Skeleton animation={false} variant="rectangular" height={160} />
+            {/* Messages in per broker */}
+            <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=37"></iframe>
+          </Grid>
+          <Grid item xs sm md>
+            {/* Bytes in per broker  */}
+            <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=24"></iframe>
+          </Grid>
+          <Grid item xs sm md>
+            {/* Bytes out per broker */}
+            <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=25"></iframe>
           </Grid>
         </Grid>
       </Box>
+
+      {/* Following were metrics we were unable to query using PromQL due to lack of documentation / bandwidth to research: */}
+      {/* <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
+        <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
+          <Grid item xs sm md>
+            Offline brokers (stat) - cannot find on Grafana Dashboards, will need to custom query
+            <Skeleton animation={false} variant="rectangular" height={160} />
+          </Grid>
+          <Grid item xs sm md>
+            // Avg RF (stat)
+            <Skeleton animation={false} variant="rectangular" height={160} />
+          </Grid>
+        </Grid>
+      </Box> */}
     </>
   );
 }

--- a/src/components/NetworkEfficiency.tsx
+++ b/src/components/NetworkEfficiency.tsx
@@ -1,7 +1,7 @@
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import Skeleton from '@mui/material/Skeleton';
+// import Skeleton from '@mui/material/Skeleton';
 
 export default function NetworkEfficiency() {
   return (
@@ -11,44 +11,45 @@ export default function NetworkEfficiency() {
       </Typography>
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
-          <Grid item xs={12} sm={12} md={12}>
+          <Grid item xs={8} sm={8} md={8}>
             {/* Avg E2E req handling time (graph) */}
             <iframe src="http://localhost:3000/d-solo/aRNaJwOmk/kafka-broker-performance-and-latency?orgId=1&refresh=5s&panelId=1"></iframe>{' '}
           </Grid>
-        </Grid>
-      </Box>
-      <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
-        <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
-          <Grid item xs sm md>
+          <Grid item xs={2} sm={2} md={2}>
             {/* Producer request rate OR req to server (broker?) / sec (graph) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=39"></iframe>{' '}
           </Grid>
-          <Grid item xs={4} sm={4} md={4}>
-            {/* Broker response rate OR res to consumers / sec (graph) */}
-            <Skeleton animation={false} variant="rectangular" height={160} />
-          </Grid>
-          <Grid item xs sm md>
+          <Grid item xs={2} sm={2} md={2}>
             {/* Consumer fetch rate OR req to server (broker?) / sec (graph) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=40"></iframe>
           </Grid>
         </Grid>
       </Box>
-      <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
+
+      {/* <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
+
+          // Following were metrics that didn't work while running demo cluster (might be hard-coded)
+          <Grid item xs={4} sm={4} md={4}>
+            // Requests in-flight (awaiting responses) (graph)
+            <iframe src="http://localhost:3000/d-solo/aRNaJwOmk/kafka-broker-performance-and-latency?orgId=1&refresh=5s&panelId=10"></iframe>
+          </Grid>
+
+          // Following were metrics we were unable to query using PromQL due to lack of documentation / bandwidth to research:
           <Grid item xs sm md>
-            {/* Failed producer request rate OR failed req to server / sec (graph) */}
+            // Failed producer request rate OR failed req to server / sec (graph)
             <Skeleton animation={false} variant="rectangular" height={160} />{' '}
           </Grid>
           <Grid item xs={4} sm={4} md={4}>
-            {/* Requests in-flight (awaiting responses) (graph) */}
-            <iframe src="http://localhost:3000/d-solo/aRNaJwOmk/kafka-broker-performance-and-latency?orgId=1&refresh=5s&panelId=10"></iframe>
+            // Broker response rate OR res to consumers / sec (graph)
+            <Skeleton animation={false} variant="rectangular" height={160} />
           </Grid>
           <Grid item xs sm md>
-            {/* Failed fetch request rate OR req to server (broker?) / sec (graph) */}
+            // Failed fetch request rate OR req to server (broker?) / sec (graph)
             <Skeleton animation={false} variant="rectangular" height={160} />
           </Grid>
         </Grid>
-      </Box>
+      </Box> */}
     </>
   );
 }

--- a/src/components/PartitionStats.tsx
+++ b/src/components/PartitionStats.tsx
@@ -1,7 +1,7 @@
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import Skeleton from '@mui/material/Skeleton';
+// import Skeleton from '@mui/material/Skeleton';
 
 export default function PartitionStats() {
   return (
@@ -11,15 +11,15 @@ export default function PartitionStats() {
       </Typography>
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
-          <Grid item xs sm md>
+          <Grid item xs={4} sm={4} md={4}>
             {/* Total leaders (stat) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=14"></iframe>
           </Grid>
-          <Grid item xs sm md>
+          <Grid item xs={4} sm={4} md={4}>
             {/* Total replicas (stat) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=15"></iframe>
           </Grid>
-          <Grid item xs sm md>
+          <Grid item xs={2} sm={2} md={2}>
             {/* Offline replicas (stat) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=32"></iframe>
           </Grid>
@@ -27,16 +27,22 @@ export default function PartitionStats() {
             {/* URPs (stat) */}
             <iframe src="http://localhost:3000/d-solo/e-6AJQOik/kafka-cluster-global-healthcheck?orgId=1&refresh=5s&panelId=33"></iframe>
           </Grid>
+        </Grid>
+      </Box>
+
+      {/* Following were metrics we were unable to query using PromQL due to lack of documentation / bandwidth to research: */}
+      {/* <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
+        <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
           <Grid item xs sm md>
-            {/* In-sync Replicas (stat) */}
+            // In-sync Replicas (stat)
             <Skeleton animation={false} variant="rectangular" height={160} />
           </Grid>
           <Grid item xs sm md>
-            {/* Out-of-sync Replicas (stat) */}
+            // Out-of-sync Replicas (stat)
             <Skeleton animation={false} variant="rectangular" height={160} />
           </Grid>
         </Grid>
-      </Box>
+      </Box> */}
     </>
   );
 }

--- a/src/components/ResourceUtil.tsx
+++ b/src/components/ResourceUtil.tsx
@@ -2,7 +2,7 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 
-export default function BrokerUtilization() {
+export default function ResourceUtilization() {
   return (
     <>
       <Typography variant="subtitle2" fontFamily="inherit" align="center">
@@ -10,7 +10,7 @@ export default function BrokerUtilization() {
       </Typography>
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
-          <Grid item xs sm md>
+          <Grid item xs={4} sm={4} md={4}>
             {/* CPU usage / broker (graph) */}
             <iframe src="http://localhost:3000/d-solo/AdG9A1xmk/kafka-brokers-jvm-and-os?orgId=1&refresh=5s&panelId=4"></iframe>
           </Grid>
@@ -18,16 +18,22 @@ export default function BrokerUtilization() {
             {/* Disk usage / broker (graph) */}
             <iframe src="http://localhost:3000/d-solo/AdG9A1xmk/kafka-brokers-jvm-and-os?orgId=1&refresh=5s&panelId=13"></iframe>
           </Grid>
-          <Grid item xs={3} sm={3} md={3}>
+          <Grid item xs sm md>
             {/* JVM memory used (graph) */}
             <iframe src="http://localhost:3000/d-solo/AdG9A1xmk/kafka-brokers-jvm-and-os?orgId=1&refresh=5s&panelId=6"></iframe>
           </Grid>
+        </Grid>
+      </Box>
+
+      {/* Following were metrics that didn't work while running demo cluster */}
+      {/* <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
+        <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
           <Grid item xs sm md>
-            {/* Time spend in GC */}
+            // Time spend in GC
             <iframe src="http://localhost:3000/d-solo/AdG9A1xmk/kafka-brokers-jvm-and-os?orgId=1&refresh=5s&panelId=10"></iframe>
           </Grid>
         </Grid>
-      </Box>
+      </Box> */}
     </>
   );
 }

--- a/src/components/TopicIO.tsx
+++ b/src/components/TopicIO.tsx
@@ -8,6 +8,8 @@ export default function TopicIO() {
       <Typography variant="subtitle2" fontFamily="inherit" align="center">
         Topics I/O
       </Typography>
+
+      {/* Following were metrics that didn't work while running demo cluster */}
       <Box component="main" sx={{ display: 'flex', flexGrow: 1, p: 3 }}>
         <Grid container spacing={{ xs: 1, sm: 1, md: 1 }}>
           <Grid item xs sm md>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,45 +10,41 @@ import {
 import { DockerMuiThemeProvider } from '@docker/docker-mui-theme';
 import CssBaseline from '@mui/material/CssBaseline';
 
+import App from './App';
+
+// outside app
 import Login from './pages/Login';
 import Signup from './pages/Signup';
+
+// in app
 import Connect from './pages/Connect';
-import App from './App';
-import BrokerIO from './components/BrokerIO';
+
+// cluster page components
 import BrokerStats from './components/BrokerStats';
-import BrokerUtilization from './components/BrokerUtil';
 import PartitionStats from './components/PartitionStats';
-import TopicIO from './components/TopicIO';
+import ResourceUtilization from './components/ResourceUtil';
 import NetworkEfficiency from './components/NetworkEfficiency';
+
+// import BrokerIO from './components/BrokerIO'; // moved iframes from this component into BrokerStats directly
+// import TopicIO from './components/TopicIO'; // unused b/c Grafana graphs don't render topic i/o during demo cluster runs
 
 const appRouter = createBrowserRouter(
   createRoutesFromElements(
     <Route path="/">
       <Route index element={<Login />} />
       <Route path="/signup" element={<Signup />} />
-      <Route path="/connect" element={<Connect />} />
-      {/* <Route index element={<App login={<Login />} />} />
-      <Route path="/signup" element={<App signup={<Signup />} />} />
-      <Route path="/connect" element={<App connect={<Connect />} />} /> */}
+      <Route path="/connect" element={<App connect={<Connect />} />} />
       <Route
         path="/cluster"
         element={
           <App
             brokerStats={<BrokerStats />}
-            brokerUtil={<BrokerUtilization />}
-            brokerIO={<BrokerIO />}
-            topicIO={<TopicIO />}
+            // brokerIO={<BrokerIO />}
+            partitionStats={<PartitionStats />}
+            resourceUtil={<ResourceUtilization />}
             networkEff={<NetworkEfficiency />}
           />
         }
-      />
-      <Route
-        path="/broker"
-        element={<App partitionStats={<PartitionStats />} />}
-      />
-      <Route
-        path="/consumer"
-        element={<App partitionStats={<PartitionStats />} />}
       />
     </Route>
   )

--- a/src/pages/Connect.tsx
+++ b/src/pages/Connect.tsx
@@ -5,6 +5,10 @@ import Paper from '@mui/material/Paper';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
 
 import './../../public/kafka-sonar-orange-logo.svg';
 
@@ -18,18 +22,29 @@ const useInput = (initValue: string) => {
 };
 
 export default function Connect(): JSX.Element {
+  // custom hook
   const [client, clientOnChange] = useInput('');
   const [host, hostOnChange] = useInput('');
   const [port, portOnChange] = useInput('');
+  // useState
+  const [auth, setAuth] = useState<string>('PLAIN');
+  // custom hook
+  const [username, usernameOnChange] = useInput('');
+  const [password, passwordOnChange] = useInput('');
+
+  // auth select handler to update state
+  const authOnChange = (e: MouseEvent) => {
+    const i = e.target.value;
+    setAuth(['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'][i]);
+  };
 
   return (
     <Paper
       elevation={2}
       style={{
         width: '60vh',
-        height: '80vh',
         padding: 20,
-        margin: '80px auto',
+        margin: '0 auto',
       }}
     >
       <img
@@ -59,7 +74,7 @@ export default function Connect(): JSX.Element {
         label="Client ID"
         fullWidth
         required
-        style={{ margin: '15px auto' }}
+        style={{ margin: '5px auto' }}
       />
       <TextField
         variant="standard"
@@ -71,7 +86,7 @@ export default function Connect(): JSX.Element {
         label="Hostname"
         fullWidth
         required
-        style={{ margin: '15px auto' }}
+        style={{ margin: '5px auto' }}
       />
       <TextField
         variant="standard"
@@ -83,7 +98,54 @@ export default function Connect(): JSX.Element {
         label="Port"
         fullWidth
         required
-        style={{ margin: '15px auto' }}
+        style={{ margin: '5px auto' }}
+      />
+      <Typography
+        fontFamily="inherit"
+        fontSize={11}
+        align="left"
+        style={{ margin: '10px auto' }}
+      >
+        Only certain SASL authentication mechanisms are currently supported.
+        <br></br>
+        SSL will be enabled so your credentials are transmitted encrypted.
+      </Typography>
+      <FormControl
+        variant="standard"
+        fullWidth
+        required
+        style={{ margin: '0 auto 5px' }}
+      >
+        <InputLabel>Authentication mechanism</InputLabel>
+        <Select name="mechanisms" onChange={authOnChange}>
+          {['PLAIN', 'SCRAM-SHA-256', 'SCRAM-SHA-512'].map((mechanism, i) => {
+            return <MenuItem value={i}>{mechanism}</MenuItem>;
+          })}
+        </Select>
+      </FormControl>
+      <TextField
+        variant="standard"
+        name="text"
+        type="text"
+        id="text"
+        value={username}
+        onChange={usernameOnChange}
+        label="Username"
+        fullWidth
+        required
+        style={{ margin: '0 auto 5px' }}
+      />
+      <TextField
+        variant="standard"
+        name="text"
+        type="text"
+        id="text"
+        value={password}
+        onChange={passwordOnChange}
+        label="Password"
+        fullWidth
+        required
+        style={{ margin: '5px auto' }}
       />
       <Button
         variant="contained"
@@ -91,14 +153,14 @@ export default function Connect(): JSX.Element {
         type="button"
         // onClick={verifyUser}
         fullWidth
-        style={{ margin: '30px auto' }}
+        style={{ margin: '20px auto 10px' }}
       >
         Quick Connect to Cluster
       </Button>
       <Typography
         align="center"
         fontFamily="inherit"
-        style={{ margin: '15px auto' }}
+        style={{ margin: '10px auto' }}
       >
         <Link to="/signup">
           For the option to save your cluster connection info, please sign up
@@ -108,7 +170,7 @@ export default function Connect(): JSX.Element {
       <Typography
         align="center"
         fontFamily="inherit"
-        style={{ margin: '15px auto' }}
+        style={{ margin: '10px auto' }}
       >
         <Link to="/">Have an account? Log in</Link>
       </Typography>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -66,7 +66,6 @@ export default function Login(): JSX.Element {
       elevation={2}
       style={{
         width: '60vh',
-        height: '70vh',
         padding: 20,
         margin: '80px auto',
       }}
@@ -128,8 +127,8 @@ export default function Login(): JSX.Element {
         style={{ margin: '15px auto' }}
       >
         <Link to="/signup">
-          For the option to save your cluster connection info, please sign up
-          for an account
+          For the option to save your cluster connection info and cluster run
+          logs, please sign up for an account
         </Link>
       </Typography>
       <Typography

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -22,9 +22,11 @@ const useInput = (initValue: string) => {
 };
 
 export default function Signup(): JSX.Element {
+  // custom hook
   const [email, emailOnChange] = useInput('');
   const [password, passwordOnChange] = useInput('');
-  const [role, setRole] = useState('User');
+  // useState
+  const [role, setRole] = useState<string>('User');
 
   // role select handler to update state
   const roleOnChange = (e: MouseEvent) => {
@@ -37,9 +39,8 @@ export default function Signup(): JSX.Element {
       elevation={2}
       style={{
         width: '60vh',
-        height: '80vh',
-        padding: 30,
-        margin: '80px auto',
+        padding: 20,
+        margin: '40px auto',
       }}
     >
       <img

--- a/src/types/types.tsx
+++ b/src/types/types.tsx
@@ -1,11 +1,9 @@
+// Login and Signup don't need to be passed as props to App b/c they display outside the app
 export default interface Props {
-  // login?: JSX.Element;
-  // signup?: JSX.Element;
-  // connect?: JSX.Element;
+  connect?: JSX.Element;
   brokerStats?: JSX.Element;
+  // brokerIO?: JSX.Element;
   partitionStats?: JSX.Element;
-  brokerUtil?: JSX.Element;
-  brokerIO?: JSX.Element;
-  topicIO?: JSX.Element;
+  resourceUtil?: JSX.Element;
   networkEff?: JSX.Element;
 }


### PR DESCRIPTION
# Overview / Task
See PR title

- [ ] Bug
- [ ] Feature
- [x] Refactoring

## Description
- Added cluster authentication fields and language about available authentication methods to Connect component
- Moved Connect component into App
- Commented out metrics that were not working or that we were unable to query using PromQL
- Reorganized remaining cluster metrics and increased widths for time series graphs to be more easily readable

## Ticket

[Trello link](https://trello.com/c/F84vufwC/25-build-functional-fe-auth-components-wip)

[Figma link](https://www.figma.com/file/hFrtcNmc9dE98ScMcFea2j/Kafka-Sonar-Prototype?type=whiteboard&node-id=0%3A1&t=dqbHWnQ33dEDoLYy-1)

## Feature Validation / Bug Reproduction Steps

1. Spin up the cluster using `docker compose -f docker-compose-cluster.yml up`.
2. Go to `http://localhost:5175/connect` to confirm Connect has moved into the app (left side nav is present).
3. Go to `http://localhost:3000/` and log in to Grafana. (Can close after successful login.)
4. Run the producer, mass producer, and consumer respectively in 3 split terminals in VSCode using
- `npm run demo-cluster-produce`
- `npm run demo-cluster-produce-mass`
- `npm run demo-cluster-consume`
5. Go to `http://localhost:5175/cluster` to confirm ALL Cluster components / metrics are showing and updating in real-time with cluster activity.

## Screenshots & Videos
![image](https://github.com/oslabs-beta/Kafka-Sonar/assets/38731992/b7da690c-5f0c-4215-9e05-23b8aeb39cf2)
![image](https://github.com/oslabs-beta/Kafka-Sonar/assets/38731992/e6bc1422-ee84-4431-a2a3-e353dd7a1935)