### PR TITLE
Updated delete connection route

### DIFF
--- a/ui/src/pages/SavedConnections.tsx
+++ b/ui/src/pages/SavedConnections.tsx
@@ -194,8 +194,9 @@ export default function SavedConnectionsDataGrid() {
     }
     // must pass user_id and cluster_id to BE
     // DELETE selected connection
+    console.log('REQUEST PARAMS', selectedClientId);
     const deletedConnection: any = await ddClient.extension.vm.service.delete(
-      `/api/clusters/${localStorage.getItem('id')}/${selectedRow}`
+      `/api/clusters/${localStorage.getItem('id')}/${selectedRow}/${selectedClientId}`
     );
     // error handling
     // refresh page, should trigger useEffect / getUserConnections, which will update state

--- a/ui/src/pages/SavedConnections.tsx
+++ b/ui/src/pages/SavedConnections.tsx
@@ -194,7 +194,6 @@ export default function SavedConnectionsDataGrid() {
     }
     // must pass user_id and cluster_id to BE
     // DELETE selected connection
-    console.log('REQUEST PARAMS', selectedClientId);
     const deletedConnection: any = await ddClient.extension.vm.service.delete(
       `/api/clusters/${localStorage.getItem('id')}/${selectedRow}/${selectedClientId}`
     );

--- a/vm/server/controllers/dockerController.ts
+++ b/vm/server/controllers/dockerController.ts
@@ -84,7 +84,7 @@ const dockerController = {
   },
   deleteClusterDirFromVolume: async (
     req: Request,
-    res: Response,
+    _res: Response,
     next: NextFunction
   ): Promise<void> => {
     const { clientId } = req.params;

--- a/vm/server/controllers/dockerController.ts
+++ b/vm/server/controllers/dockerController.ts
@@ -1,5 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import Dockerode from 'dockerode';
+import pkg from 'fs-extra';
+const { removeSync } = pkg;
 import createPromContainerCreateOpts from '../utils/promContainerCreateOptions';
 import createGrafContainerCreateOpts from '../utils/grafContainerCreateOptions'
 
@@ -52,11 +54,11 @@ const dockerController = {
   },
   removeMetricsContainers: async (
     req: Request,
-    _res: Response,
+    res: Response,
     next: NextFunction
   ): Promise<void> => {
     const { client_id} = req.params;
-    const clusterDir = client_id
+    const clusterDir = client_id;
     const containers = await docker.listContainers();
     const regex = new RegExp('/' + clusterDir + '-kafkasonar-', 'g')
     // instantiate a counter to track how many metrics containers have been removed
@@ -80,6 +82,25 @@ const dockerController = {
       });
     }
   },
+  deleteClusterDirFromVolume: async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    const { clientId } = req.params;
+    const clusterDir = clientId;
+    // remove the directory that matches ./user/${clusterDir}
+    try {
+      removeSync(`./user/${clusterDir}`);
+      return next();
+    } catch (err) {
+      return next({
+        log: 'Error occured in dockerController.deleteClusterDir Middleware',
+        message: { err: JSON.stringify(err, Object.getOwnPropertyNames(err))}
+      });
+    }
+
+  }
 }
 
 export default dockerController;

--- a/vm/server/controllers/dockerController.ts
+++ b/vm/server/controllers/dockerController.ts
@@ -54,7 +54,7 @@ const dockerController = {
   },
   removeMetricsContainers: async (
     req: Request,
-    res: Response,
+    _res: Response,
     next: NextFunction
   ): Promise<void> => {
     const { client_id} = req.params;

--- a/vm/server/routes/clusterRouter.ts
+++ b/vm/server/routes/clusterRouter.ts
@@ -55,10 +55,11 @@ clusterRouter.get(
 
 // SAVED CONNECTIONS deleteUserConnection - DONE. Working fullstack.
 clusterRouter.delete(
-  '/:user_id/:cluster_id',
+  '/:user_id/:cluster_id/:clientId',
   clusterController.deleteCluster,
   clusterController.deleteUserCluster,
   clusterController.deleteJmxPort,
+  dockerController.deleteClusterDirFromVolume,
   (_req: Request, res: Response, _next: NextFunction): void => {
     res.sendStatus(200);
   }


### PR DESCRIPTION
# Overview

## Task

- [x] Bug
- [ ] Feature

## Description
Added a new middleware to the dockerController to remove the directory holding a specific cluster's configs. Updated the deleteUserConnection function in `SavedConnections.tsx` to pass the selectedClientId as parameters for the delete request. This allows the dockerController middleware to locate the proper directory for deletion.

## Ticket

[Trello](https://trello.com/c/rjkueYkL/36-update-delete-connection-to-remove-clusters-directory-from-user-volume)

## Feature Validation / Bug Reproduction Steps

1. `make update-extension`
2. Log into Kafka Sonar and add a new connection, the content doesn't matter as you're just going to delete it.
3. Once the connection is added, navigate either to the kafka-sonar container and go to files -> backend/user and confirm that your newly added connection has a directory (directory is named after Client Id from step 2). Alternatively, you can go to the volumes tab on the Docker Desktop sidebar and check the kafkasonar user volume there. In that case, click the volume called 'kafkasonar_kafkasonar-desktop-extension_user" and click on the data tab. Confirm that a directory exists named after your new connection.
4. Go back into the Kafka Sonar extension, click your newly added connection on the DataGrid, and then click the button Delete Selected Connection.
5. Check the user volume again in either place. Your connection's directory should be gone.

## Previous Behavior
The delete connection route deleted a user's connection from the database, but did not clear out that connection's directory of configuration files in the user volume.

## Expected Behavior
Deleting a connection now properly clears out that connection's configuration from the user volume.
